### PR TITLE
Optimization strategy changed, allowed for precise number of samples, revealed flags to trainloop improved epoch reporting

### DIFF
--- a/swyft/__init__.py
+++ b/swyft/__init__.py
@@ -1,7 +1,7 @@
-from .store import DirectoryStore, MemoryStore, Dataset, Simulator
-from .bounds import Prior, Bound
-from .inference import Posteriors, Microscope
-from .networks import OnlineNormalizationLayer, Module, DefaultHead, DefaultTail
+from .bounds import Bound, Prior
+from .inference import Microscope, Posteriors
+from .networks import DefaultHead, DefaultTail, Module, OnlineNormalizationLayer
+from .store import Dataset, DirectoryStore, MemoryStore, Simulator
 from .utils import corner, plot1d
 
 __all__ = [

--- a/swyft/bounds/bounds.py
+++ b/swyft/bounds/bounds.py
@@ -1,9 +1,11 @@
-import numpy as np
-from sklearn.neighbors import BallTree
-import torch
 import logging
 
+import numpy as np
+import torch
+from sklearn.neighbors import BallTree
+
 from swyft.inference import IsolatedRatio
+
 
 # FIXME: Add docstring
 class Bound:

--- a/swyft/inference/__init__.py
+++ b/swyft/inference/__init__.py
@@ -1,5 +1,5 @@
-from .posteriors import Posteriors
 from .microscope import Microscope
+from .posteriors import Posteriors
 from .ratios import IsolatedRatio
 
 __all__ = ["Posteriors", "Microscope", "IsolatedRatio"]

--- a/swyft/inference/microscope.py
+++ b/swyft/inference/microscope.py
@@ -3,11 +3,11 @@ from warnings import warn
 
 import numpy as np
 
-from .posteriors import Posteriors
+import swyft
 from swyft.networks import DefaultHead, DefaultTail
 from swyft.utils import all_finite, format_param_list
-import swyft
 
+from .posteriors import Posteriors
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 

--- a/swyft/inference/microscope.py
+++ b/swyft/inference/microscope.py
@@ -1,13 +1,9 @@
 import logging
-from warnings import warn
-
-import numpy as np
 
 import swyft
+from swyft.inference.posteriors import Posteriors
 from swyft.networks import DefaultHead, DefaultTail
 from swyft.utils import all_finite, format_param_list
-
-from .posteriors import Posteriors
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
@@ -84,6 +80,8 @@ class Microscope:
         self._datasets = []
         self._posteriors = []
         self._next_priors = []
+        self._initial_n_simulations = len(store)
+        self._n_simulations = []
 
     def status(self):
         pass
@@ -150,6 +148,7 @@ class Microscope:
                     N, prior, store=self._store, simhook=self._simhook
                 )
 
+                self._n_simulations.append(len(self._store))
                 self._datasets.append(dataset)
                 self._status = 1
 
@@ -219,6 +218,10 @@ class Microscope:
     @property
     def N(self):
         return [len(dataset) for dataset in self._datasets]
+
+    @property
+    def n_simulations(self):
+        return [ns - self._initial_n_simulations for ns in self._n_simulations]
 
     @property
     def converged(self):

--- a/swyft/inference/posteriors.py
+++ b/swyft/inference/posteriors.py
@@ -5,9 +5,8 @@ import numpy as np
 import torch
 
 import swyft
+from swyft.inference.ratios import JoinedRatioCollection, RatioCollection
 from swyft.networks import DefaultHead, DefaultTail
-
-from .ratios import JoinedRatioCollection, RatioCollection
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 

--- a/swyft/inference/posteriors.py
+++ b/swyft/inference/posteriors.py
@@ -1,13 +1,13 @@
 import logging
 from warnings import warn
 
-import torch
 import numpy as np
+import torch
 
-from .ratios import RatioCollection, JoinedRatioCollection
-from swyft.networks import DefaultHead, DefaultTail
 import swyft
+from swyft.networks import DefaultHead, DefaultTail
 
+from .ratios import JoinedRatioCollection, RatioCollection
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 

--- a/swyft/inference/ratios.py
+++ b/swyft/inference/ratios.py
@@ -2,10 +2,9 @@
 from typing import Optional
 
 import numpy as np
-import torch.nn as nn
 import torch
+import torch.nn as nn
 
-from .train import trainloop
 from swyft.networks import DefaultHead, DefaultTail, Module
 from swyft.types import Array, Device, Sequence, Tuple
 from swyft.utils import (
@@ -14,6 +13,8 @@ from swyft.utils import (
     format_param_list,
     get_obs_shapes,
 )
+
+from .train import trainloop
 
 
 class IsolatedRatio:
@@ -63,7 +64,6 @@ class RatioCollection:
 
         Args:
             points: points dataset from the iP3 sample store
-            combinations: which combinations of z parameters to learn
             head: initialized module which processes observations, head(x0) = y
             previous_ratio_estimator: ratio estimator from another round. if given, reuse head.
             device: default is cpu
@@ -99,22 +99,19 @@ class RatioCollection:
     def train(
         self,
         dataset,
-        max_epochs: int = 10,
-        batch_size: int = 32,
-        lr_schedule: Sequence[float] = [1e-3, 3e-4, 1e-4],
-        early_stopping_patience: int = 1,
-        nworkers: int = 0,
+        batch_size=64,
         percent_validation=0.1,
+        early_stopping_patience=10,
+        max_epochs=50,
+        lr=1e-3,
+        reduce_lr_factor=0.1,
+        reduce_lr_patience=5,
+        nworkers=0,
     ) -> None:
         """Train higher-dimensional marginal posteriors.
 
         Args:
-            max_epochs: maximum number of training epochs
-            batch_size: minibatch size
-            lr_schedule: list of learning rates
-            early_stopping_patience: early stopping patience
             nworkers: number of Dataloader workers (0 for no dataloader parallelization)
-            percent_validation: percentage to allocate to validation set
         """
 
         if self.tail is None:
@@ -124,36 +121,28 @@ class RatioCollection:
         self.tail.train()
 
         diagnostics = trainloop(
-            self.head,
-            self.tail,
-            dataset,
-            combinations=None,
-            device=self.device,
-            max_epochs=max_epochs,
+            head=self.head,
+            tail=self.tail,
+            dataset=dataset,
             batch_size=batch_size,
-            lr_schedule=lr_schedule,
-            early_stopping_patience=early_stopping_patience,
-            nworkers=nworkers,
             percent_validation=percent_validation,
+            early_stopping_patience=early_stopping_patience,
+            max_epochs=max_epochs,
+            lr=lr,
+            reduce_lr_factor=reduce_lr_factor,
+            reduce_lr_patience=reduce_lr_patience,
+            nworkers=nworkers,
+            device=self.device,
         )
         self._train_diagnostics.append(diagnostics)
 
-    # FIXME: Type annotations and docstring are wrong
     def ratios(
         self,
-        obs: Array,
-        params: Array,
+        obs,
+        params,
         n_batch=100,
-    ) -> Tuple[np.ndarray, np.ndarray]:
-        """Retrieve estimated marginal posterior.
-
-        Args:
-            x0: real observation to calculate posterior
-            combination_indices: z indices in self.combinations
-
-        Returns:
-            parameter array, posterior array
-        """
+    ):
+        """Retrieve estimated marginal posterior."""
 
         self.head.eval()
         self.tail.eval()

--- a/swyft/inference/ratios.py
+++ b/swyft/inference/ratios.py
@@ -5,16 +5,10 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from swyft.inference.train import trainloop
 from swyft.networks import DefaultHead, DefaultTail, Module
-from swyft.types import Array, Device, Sequence, Tuple
-from swyft.utils import (
-    dict_to_tensor,
-    dict_to_tensor_unsqueeze,
-    format_param_list,
-    get_obs_shapes,
-)
-
-from .train import trainloop
+from swyft.types import Array, Device
+from swyft.utils import dict_to_tensor_unsqueeze, format_param_list, get_obs_shapes
 
 
 class IsolatedRatio:
@@ -100,7 +94,7 @@ class RatioCollection:
         self,
         dataset,
         batch_size=64,
-        percent_validation=0.1,
+        validation_size=0.1,
         early_stopping_patience=10,
         max_epochs=50,
         lr=1e-3,
@@ -126,7 +120,7 @@ class RatioCollection:
             tail=self.tail,
             dataset=dataset,
             batch_size=batch_size,
-            percent_validation=percent_validation,
+            validation_size=validation_size,
             early_stopping_patience=early_stopping_patience,
             max_epochs=max_epochs,
             lr=lr,

--- a/swyft/inference/ratios.py
+++ b/swyft/inference/ratios.py
@@ -107,6 +107,7 @@ class RatioCollection:
         reduce_lr_factor=0.1,
         reduce_lr_patience=5,
         nworkers=0,
+        **kwargs,
     ) -> None:
         """Train higher-dimensional marginal posteriors.
 
@@ -133,6 +134,7 @@ class RatioCollection:
             reduce_lr_patience=reduce_lr_patience,
             nworkers=nworkers,
             device=self.device,
+            **kwargs,
         )
         self._train_diagnostics.append(diagnostics)
 

--- a/swyft/inference/train.py
+++ b/swyft/inference/train.py
@@ -34,7 +34,9 @@ def train(
     validation_loader,
     early_stopping_patience,
     max_epochs,
+    optimizer_fn,
     lr,
+    scheduler_fn,
     reduce_lr_factor,
     reduce_lr_patience,
     device="cpu",
@@ -78,8 +80,8 @@ def train(
 
     max_epochs = 2 ** 31 - 1 if max_epochs is None else max_epochs
     params = list(head.parameters()) + list(tail.parameters())
-    optimizer = torch.optim.Adam(params, lr=lr)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+    optimizer = optimizer_fn(params, lr=lr)
+    scheduler = scheduler_fn(
         optimizer,
         factor=reduce_lr_factor,
         patience=reduce_lr_patience,
@@ -126,7 +128,9 @@ def trainloop(
     percent_validation=0.1,
     early_stopping_patience=10,
     max_epochs=50,
+    optimizer_fn=torch.optim.Adam,
     lr=1e-3,
+    scheduler_fn=torch.optim.lr_scheduler.ReduceLROnPlateau,
     reduce_lr_factor=0.1,
     reduce_lr_patience=5,
     nworkers=0,
@@ -137,7 +141,9 @@ def trainloop(
     logging.debug(f"{'percent_validation':>25} {percent_validation:<4}")
     logging.debug(f"{'early_stopping_patience':>25} {early_stopping_patience:<4}")
     logging.debug(f"{'max_epochs':>25} {max_epochs:<4}")
+    logging.debug(f"{'optimizer_fn':>25} {repr(optimizer_fn):<4}")
     logging.debug(f"{'lr':>25} {lr:<4}")
+    logging.debug(f"{'scheduler_fn':>25} {repr(scheduler_fn):<4}")
     logging.debug(f"{'reduce_lr_factor':>25} {reduce_lr_factor:<4}")
     logging.debug(f"{'reduce_lr_patience':>25} {reduce_lr_patience:<4}")
     logging.debug(f"{'nworkers':>25} {nworkers:<4}")
@@ -171,7 +177,9 @@ def trainloop(
         valid_loader,
         early_stopping_patience=early_stopping_patience,
         max_epochs=max_epochs,
+        optimizer_fn=optimizer_fn,
         lr=lr,
+        scheduler_fn=scheduler_fn,
         reduce_lr_factor=reduce_lr_factor,
         reduce_lr_patience=reduce_lr_patience,
         device=device,

--- a/swyft/inference/train.py
+++ b/swyft/inference/train.py
@@ -86,8 +86,8 @@ def train(
         patience=reduce_lr_patience,
     )
 
-    n_train_batches = len(train_loader) if len(train_loader) < 0 else 1
-    n_validation_batches = len(validation_loader) if len(validation_loader) < 0 else 1
+    n_train_batches = len(train_loader) if len(train_loader) != 0 else 1
+    n_validation_batches = len(validation_loader) if len(validation_loader) != 0 else 1
 
     train_losses, validation_losses = [], []
     epoch, fruitless_epoch, min_loss = 0, 0, float("Inf")
@@ -123,12 +123,12 @@ def train(
     return train_losses, validation_losses, best_state_dict_head, best_state_dict_tail
 
 
-def _get_nvalid_ntrain(validation_size, len_dataset):
+def _get_ntrain_nvalid(validation_size, len_dataset):
     if isinstance(validation_size, float):
         percent_validation = validation_size
         percent_train = 1.0 - percent_validation
-        nvalid, ntrain = split_length_by_percentage(
-            len_dataset, (percent_validation, percent_train)
+        ntrain, nvalid = split_length_by_percentage(
+            len_dataset, (percent_train, percent_validation)
         )
         if nvalid % 2 != 0:
             nvalid += 1
@@ -143,7 +143,7 @@ def _get_nvalid_ntrain(validation_size, len_dataset):
             ntrain -= 1
     else:
         raise TypeError()
-    return nvalid, ntrain
+    return ntrain, nvalid
 
 
 def trainloop(
@@ -175,7 +175,7 @@ def trainloop(
     logging.debug(f"{'nworkers':>25} {nworkers:<4}")
 
     assert validation_size > 0
-    ntrain, nvalid = _get_nvalid_ntrain(validation_size, len(dataset))
+    ntrain, nvalid = _get_ntrain_nvalid(validation_size, len(dataset))
 
     dataset_train, dataset_valid = torch.utils.data.random_split(
         dataset, [ntrain, nvalid]

--- a/swyft/inference/train.py
+++ b/swyft/inference/train.py
@@ -133,14 +133,14 @@ def trainloop(
     device="cpu",
 ):
     logging.debug("Entering trainloop")
-    logging.debug(f"  batch_size {batch_size:>5}")
-    logging.debug(f"  percent_validation {percent_validation:>5}")
-    logging.debug(f"  early_stopping_patience {early_stopping_patience:>5}")
-    logging.debug(f"  max_epochs {max_epochs:>5}")
-    logging.debug(f"  lr {lr:>5}")
-    logging.debug(f"  reduce_lr_factor {reduce_lr_factor:>5}")
-    logging.debug(f"  reduce_lr_patience {reduce_lr_patience:>5}")
-    logging.debug(f"  nworkers {nworkers:>5}")
+    logging.debug(f"{'batch_size':>25} {batch_size:<4}")
+    logging.debug(f"{'percent_validation':>25} {percent_validation:<4}")
+    logging.debug(f"{'early_stopping_patience':>25} {early_stopping_patience:<4}")
+    logging.debug(f"{'max_epochs':>25} {max_epochs:<4}")
+    logging.debug(f"{'lr':>25} {lr:<4}")
+    logging.debug(f"{'reduce_lr_factor':>25} {reduce_lr_factor:<4}")
+    logging.debug(f"{'reduce_lr_patience':>25} {reduce_lr_patience:<4}")
+    logging.debug(f"{'nworkers':>25} {nworkers:<4}")
 
     percent_train = 1.0 - percent_validation
     nvalid, ntrain = split_length_by_percentage(

--- a/swyft/inference/train.py
+++ b/swyft/inference/train.py
@@ -7,9 +7,8 @@ from typing import Sequence
 import numpy as np
 import torch
 
+from swyft.inference.loss import loss_fn
 from swyft.utils import dict_to_device
-
-from .loss import loss_fn
 
 
 def split_length_by_percentage(length: int, percents: Sequence[float]) -> Sequence[int]:
@@ -87,8 +86,8 @@ def train(
         patience=reduce_lr_patience,
     )
 
-    n_train_batches = len(train_loader) if len(train_loader) != 0 else 1
-    n_validation_batches = len(validation_loader) if len(validation_loader) != 0 else 1
+    n_train_batches = len(train_loader) if len(train_loader) < 0 else 1
+    n_validation_batches = len(validation_loader) if len(validation_loader) < 0 else 1
 
     train_losses, validation_losses = [], []
     epoch, fruitless_epoch, min_loss = 0, 0, float("Inf")
@@ -124,12 +123,35 @@ def train(
     return train_losses, validation_losses, best_state_dict_head, best_state_dict_tail
 
 
+def _get_nvalid_ntrain(validation_size, len_dataset):
+    if isinstance(validation_size, float):
+        percent_validation = validation_size
+        percent_train = 1.0 - percent_validation
+        nvalid, ntrain = split_length_by_percentage(
+            len_dataset, (percent_validation, percent_train)
+        )
+        if nvalid % 2 != 0:
+            nvalid += 1
+            ntrain -= 1
+    elif isinstance(validation_size, int):
+        nvalid = validation_size
+        ntrain = len_dataset - nvalid
+        assert ntrain > 0
+
+        if nvalid % 2 != 0:
+            nvalid += 1
+            ntrain -= 1
+    else:
+        raise TypeError()
+    return nvalid, ntrain
+
+
 def trainloop(
     head,
     tail,
     dataset,
     batch_size=64,
-    percent_validation=0.1,
+    validation_size=0.1,
     early_stopping_patience=10,
     max_epochs=50,
     optimizer_fn=torch.optim.Adam,
@@ -142,7 +164,7 @@ def trainloop(
 ):
     logging.debug("Entering trainloop")
     logging.debug(f"{'batch_size':>25} {batch_size:<4}")
-    logging.debug(f"{'percent_validation':>25} {percent_validation:<4}")
+    logging.debug(f"{'validation_size':>25} {validation_size:<4}")
     logging.debug(f"{'early_stopping_patience':>25} {early_stopping_patience:<4}")
     logging.debug(f"{'max_epochs':>25} {max_epochs:<4}")
     logging.debug(f"{'optimizer_fn':>25} {repr(optimizer_fn):<4}")
@@ -152,10 +174,9 @@ def trainloop(
     logging.debug(f"{'reduce_lr_patience':>25} {reduce_lr_patience:<4}")
     logging.debug(f"{'nworkers':>25} {nworkers:<4}")
 
-    percent_train = 1.0 - percent_validation
-    nvalid, ntrain = split_length_by_percentage(
-        len(dataset), (percent_validation, percent_train)
-    )
+    assert validation_size > 0
+    ntrain, nvalid = _get_nvalid_ntrain(validation_size, len(dataset))
+
     dataset_train, dataset_valid = torch.utils.data.random_split(
         dataset, [ntrain, nvalid]
     )
@@ -168,12 +189,11 @@ def trainloop(
     )
     valid_loader = torch.utils.data.DataLoader(
         dataset_valid,
-        batch_size=batch_size,
+        batch_size=min(batch_size, nvalid),
         num_workers=nworkers,
         pin_memory=True,
         drop_last=True,
     )
-
     tl, vl, sd_head, sd_tail = train(
         head,
         tail,

--- a/swyft/inference/train.py
+++ b/swyft/inference/train.py
@@ -103,7 +103,6 @@ def train(
         tail.eval()
         validation_loss = do_epoch(validation_loader, False)
         avg_validation_loss = validation_loss / n_validation_batches
-        logging.debug("validation loss = %.4g" % (avg_validation_loss))
         validation_losses.append(avg_validation_loss)
 
         epoch += 1
@@ -116,6 +115,11 @@ def train(
         else:
             fruitless_epoch += 1
         scheduler.step(avg_validation_loss)
+        print(
+            f"Epoch {epoch}. Validation Loss {avg_validation_loss:.4g}",
+            end="\r",
+            flush=True,
+        )
 
     return train_losses, validation_losses, best_state_dict_head, best_state_dict_tail
 

--- a/swyft/networks/__init__.py
+++ b/swyft/networks/__init__.py
@@ -2,10 +2,10 @@
 # from .linear import LinearWithChannel
 # from .resnet import ResidualNet
 
-from .module import Module
-from .tail import DefaultTail
 from .head import DefaultHead
+from .module import Module
 from .normalization import OnlineNormalizationLayer
+from .tail import DefaultTail
 
 __all__ = [
     #    "BatchNorm1dWithChannel",

--- a/swyft/store/__init__.py
+++ b/swyft/store/__init__.py
@@ -1,6 +1,6 @@
-from .store import DirectoryStore, MemoryStore
 from .dataset import Dataset
 from .simulator import Simulator
+from .store import DirectoryStore, MemoryStore
 
 __all__ = [
     "MemoryStore",

--- a/swyft/store/dataset.py
+++ b/swyft/store/dataset.py
@@ -10,7 +10,7 @@ import swyft
 class Dataset(torch_Dataset):
     """Dataset for access to swyft.Store."""
 
-    def __init__(self, N, prior, store, simhook=None):
+    def __init__(self, N, prior, store, simhook=None, exactly_n: bool = False):
         """Initialize Dataset.
 
         Args:
@@ -18,6 +18,7 @@ class Dataset(torch_Dataset):
             prior (swyft.Prior): Parameter prior.
             store (swyft.Store): Store reference.
             simhook (Callable): Posthook for simulations. Applied on-the-fly to each point.
+            exactly_n (bool): Produce exactly N samples, rather than N_ ~ Poisson(N).
 
         Notes:
             Due to the statistical nature of the Store, the returned number of
@@ -27,7 +28,7 @@ class Dataset(torch_Dataset):
         super().__init__()
 
         # Initialization
-        indices = store.sample(N, prior)
+        indices = store.sample(N, prior, exactly_n=exactly_n)
 
         self._prior = prior
         self._indices = indices

--- a/swyft/store/store.py
+++ b/swyft/store/store.py
@@ -214,6 +214,8 @@ class Store(ABC):
             self.log_lambdas.resize(len(self.log_lambdas) + 1)
             self.log_lambdas[-1] = dict(pdf=pdf.state_dict(), N=N)
 
+        logging.info(f"  total size of simulator store {len(self)}.")
+
         self._update()
 
         # Select points from cache

--- a/swyft/store/store.py
+++ b/swyft/store/store.py
@@ -12,9 +12,9 @@ import numcodecs
 import numpy as np
 import zarr
 
+import swyft
 from swyft.types import Array, PathType, Shape
 from swyft.utils import all_finite, is_empty
-import swyft
 
 
 class SimulationStatus(enum.IntEnum):

--- a/swyft/store/store.py
+++ b/swyft/store/store.py
@@ -191,11 +191,14 @@ class Store(ABC):
             d = np.where(r > d, r, d)
         return d
 
-    def sample(self, N, pdf):
+    def sample(self, N, pdf, exactly_n: bool = False):
         self._update()
 
         # Generate new points
-        z_prop = pdf.sample(N=np.random.poisson(N))
+        if exactly_n:
+            z_prop = pdf.sample(N=N)
+        else:
+            z_prop = pdf.sample(N=np.random.poisson(N))
         log_lambda_target = pdf.log_prob(z_prop) + np.log(N)
         log_lambda_store = self.log_lambda(z_prop)
         log_w = np.log(np.random.rand(len(z_prop))) + log_lambda_target

--- a/swyft/types.py
+++ b/swyft/types.py
@@ -15,8 +15,6 @@ Array = Union[np.ndarray, torch.Tensor]
 
 WeightsType = Dict[Tuple[int], np.ndarray]
 
-Combinations = Union[int, Sequence[int], Sequence[Sequence[int]]]
-
 Shape = Union[torch.Size, Tuple[int, ...]]
 DictInt = Union[int, Dict[str, int]]
 DictShape = Union[Shape, Dict[str, Shape]]

--- a/swyft/utils/__init__.py
+++ b/swyft/utils/__init__.py
@@ -1,5 +1,5 @@
 from .array import *
 from .device import *
 from .parameters import *
-from .utils import *
 from .plot import *
+from .utils import *

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -1,12 +1,14 @@
 import tempfile
+import time
+from itertools import product
+from pathlib import Path
+
 import numpy as np
 import pytest
-import time
-from pathlib import Path
-from itertools import product
+
+from swyft import Prior
 from swyft.cache.cache import Cache, DirectoryCache, MemoryCache
 from swyft.utils.simulator import Simulator
-from swyft import Prior
 
 
 def model(params):

--- a/tests/simulator_test.py
+++ b/tests/simulator_test.py
@@ -1,7 +1,9 @@
-import pytest
 import numpy as np
+import pytest
 from dask.distributed import LocalCluster
+
 from swyft.utils.simulator import Simulator
+
 
 # linear model
 def model(params):


### PR DESCRIPTION
The primary changes are to allow for the use of pytorch schedulers
https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
These are simply more flexible and easier to customize than what we used before. Furthermore, they do not do wasted training by retraining at low learning rates when the method already converged.

I also revealed these flags in `train_args`.

I updated some reporting things. Now epochs are listed and the line is overwritten, thus removing clutter.

Now you can select an exact number of samples to draw from the store. This is useful for model comparison.