### PR TITLE
Add flag to average std in OnlineNormalizationLayer

### DIFF
--- a/swyft/networks/normalization.py
+++ b/swyft/networks/normalization.py
@@ -10,7 +10,7 @@ class OnlineNormalizationLayer(nn.Module):
         shape,
         stable: bool = False,
         epsilon: float = 1e-10,
-        average_std: bool = False,
+        use_average_std: bool = False,
     ):
         """Accumulate mean and variance online using the "parallel algorithm" algorithm from [1].
 
@@ -18,7 +18,7 @@ class OnlineNormalizationLayer(nn.Module):
             shape (tuple): shape of mean, variance, and std array. do not include batch dimension!
             stable (bool): (optional) compute using the stable version of the algorithm [1]
             epsilon (float): (optional) added to the computation of the standard deviation for numerical stability.
-            average_std (bool): (optional) ``True`` to normalize using std averaged over the whole observation, ``False`` to normalize using std of each component of the observation.
+            use_average_std (bool): (optional) ``True`` to normalize using std averaged over the whole observation, ``False`` to normalize using std of each component of the observation.
 
         References:
             [1] https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
@@ -30,7 +30,7 @@ class OnlineNormalizationLayer(nn.Module):
         self.register_buffer("epsilon", torch.tensor(epsilon))
         self.shape = shape
         self.stable = stable
-        self.average_std = average_std
+        self.use_average_std = use_average_std
 
     def _parallel_algorithm(self, x):
         assert x.shape[1:] == self.shape
@@ -71,7 +71,7 @@ class OnlineNormalizationLayer(nn.Module):
 
     @property
     def std(self):
-        if self.average_std:
+        if self.use_average_std:
             return torch.sqrt(self.var + self.epsilon).mean()
         else:
             return torch.sqrt(self.var + self.epsilon)

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -76,7 +76,7 @@ class TestNormalizationLayer:
     def test_online_normalization_layer_std_average(self, bs, shape, mean, std, stable):
         torch.manual_seed(0)
 
-        onl = OnlineNormalizationLayer(shape, stable=stable, average_std=True)
+        onl = OnlineNormalizationLayer(shape, stable=stable, use_average_std=True)
         onl.train()
 
         data = torch.randn(bs, *shape) * std + mean

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -4,7 +4,7 @@ from itertools import product
 import pytest
 import torch
 
-from swyft.nn.normalization import OnlineNormalizationLayer
+from swyft.networks.normalization import OnlineNormalizationLayer
 
 
 class TestNormalizationLayer:
@@ -69,6 +69,24 @@ class TestNormalizationLayer:
             assert torch.allclose(onl.std, replacement_std)
         else:
             assert torch.allclose(onl.std, data.std(0))
+
+    @pytest.mark.parametrize(
+        "bs, shape, mean, std, stable", product(bss, shapes, means, stds, stables)
+    )
+    def test_online_normalization_layer_std_average(self, bs, shape, mean, std, stable):
+        torch.manual_seed(0)
+
+        onl = OnlineNormalizationLayer(shape, stable=stable, average_std=True)
+        onl.train()
+
+        data = torch.randn(bs, *shape) * std + mean
+        _ = onl(data)
+
+        if torch.isnan(data.std(0)).all():
+            replacement_std = torch.sqrt(torch.ones_like(onl.std) * onl.epsilon)
+            assert torch.allclose(onl.std, replacement_std.mean())
+        else:
+            assert torch.allclose(onl.std, data.std(0).mean())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a flag `use_average_std` to the `OnlineNormalizationLayer` initializer to average the standard deviation over components of the observation. This is useful for avoiding `std ~ 0`, which can happen if some of the observation components are constant across all training samples.

Also adds a test to `tests/network_test.py`.