### PR TITLE
Empirical mass and improved plotting

### DIFF
--- a/notebooks/Examples - 1. Head networks.ipynb
+++ b/notebooks/Examples - 1. Head networks.ipynb
@@ -235,7 +235,7 @@
     "obs0 = dataset[i][0]\n",
     "v0 = dataset[i][2]\n",
     "samples=post.sample(100000, obs0)\n",
-    "swyft.plot1d(samples, [0, 1, 2], truth = v0, figsize = (12, 4), bins = 100);"
+    "swyft.plot_1d(samples, [0, 1, 2], truth = v0, figsize = (12, 4), bins = 100);"
    ]
   },
   {
@@ -280,7 +280,7 @@
     "obs0 = dataset[i][0]\n",
     "v0 = dataset[i][2]\n",
     "samples = post.sample(100000, obs0)\n",
-    "swyft.corner(samples, [0, 1, 2], truth = v0, bins = 50);"
+    "swyft.plot_corner(samples, [0, 1, 2], truth = v0, bins = 50);"
    ]
   }
  ],

--- a/notebooks/Examples - 2. Truncation.ipynb
+++ b/notebooks/Examples - 2. Truncation.ipynb
@@ -141,7 +141,7 @@
    ],
    "source": [
     "samples = post.sample(1000000, obs0)\n",
-    "swyft.corner(samples, [0, 1], color='k', figsize = (8,8), truth=v0, bins = 40);"
+    "swyft.plot_corner(samples, [0, 1], color='k', figsize = (8,8), truth=v0, bins = 40);"
    ]
   },
   {

--- a/notebooks/Examples - 3. Saving and Loading.ipynb
+++ b/notebooks/Examples - 3. Saving and Loading.ipynb
@@ -213,7 +213,7 @@
     "obs0 = dataset[i][0]\n",
     "v0 = dataset[i][2]\n",
     "samples=post.sample(100000, obs0)\n",
-    "swyft.plot1d(samples, [0, 1], truth = v0, figsize = (12, 4), bins = 100);"
+    "swyft.plot_1d(samples, [0, 1], truth = v0, figsize = (12, 4), bins = 100);"
    ]
   },
   {

--- a/swyft/__init__.py
+++ b/swyft/__init__.py
@@ -2,7 +2,7 @@ from swyft.bounds import Bound, Prior, TruncatedPrior
 from swyft.inference import Posteriors, TrainOptions
 from swyft.networks import DefaultHead, DefaultTail, Module, OnlineNormalizationLayer
 from swyft.store import DaskSimulator, Dataset, DirectoryStore, MemoryStore, Simulator
-from swyft.utils import plot_corner, plot_1d, plot_empirical_mass
+from swyft.utils import plot_1d, plot_corner, plot_empirical_mass
 
 
 def zen():

--- a/swyft/__init__.py
+++ b/swyft/__init__.py
@@ -2,7 +2,7 @@ from swyft.bounds import Bound, Prior, TruncatedPrior
 from swyft.inference import Posteriors, TrainOptions
 from swyft.networks import DefaultHead, DefaultTail, Module, OnlineNormalizationLayer
 from swyft.store import DaskSimulator, Dataset, DirectoryStore, MemoryStore, Simulator
-from swyft.utils import corner, plot1d
+from swyft.utils import plot_corner, plot_1d, plot_empirical_mass
 
 
 def zen():
@@ -28,6 +28,7 @@ __all__ = [
     "Dataset",
     "Simulator",
     "DaskSimulator",
-    "corner",
-    "plot1d",
+    "plot_corner",
+    "plot_1d",
+    "plot_empirical_mass",
 ]

--- a/swyft/bounds/prior.py
+++ b/swyft/bounds/prior.py
@@ -20,11 +20,7 @@ class TruncatedPrior:
         the samples onto parameters of interest.
     """
 
-    def __init__(
-        self,
-        prior: "Prior",
-        bound: Bound,
-    ) -> None:
+    def __init__(self, prior: "Prior", bound: Bound) -> None:
         """Instantiate truncated prior (combination of prior and bound).
 
         Args:
@@ -86,12 +82,7 @@ class TruncatedPrior:
 
 
 class Prior:
-    def __init__(
-        self,
-        uv: Callable,
-        zdim: int,
-        n: int = 10000,
-    ) -> None:
+    def __init__(self, uv: Callable, zdim: int, n: int = 10000) -> None:
         r"""1-dim parameter prior.
 
         Args:

--- a/swyft/store/__init__.py
+++ b/swyft/store/__init__.py
@@ -2,10 +2,4 @@ from swyft.store.dataset import Dataset
 from swyft.store.simulator import DaskSimulator, Simulator
 from swyft.store.store import DirectoryStore, MemoryStore
 
-__all__ = [
-    "MemoryStore",
-    "DirectoryStore",
-    "Dataset",
-    "Simulator",
-    "DaskSimulator",
-]
+__all__ = ["MemoryStore", "DirectoryStore", "Dataset", "Simulator", "DaskSimulator"]

--- a/swyft/store/dataset.py
+++ b/swyft/store/dataset.py
@@ -124,11 +124,7 @@ class Dataset(torch_Dataset):
             x = self._simhook(x, v)
         u = self._trunc_prior.prior.u(v.reshape(1, -1)).flatten()
 
-        return (
-            self._tensorfy(x),
-            array_to_tensor(u),
-            array_to_tensor(v),
-        )
+        return (self._tensorfy(x), array_to_tensor(u), array_to_tensor(v))
 
     def state_dict(self) -> dict:
         return dict(

--- a/swyft/store/simulator.py
+++ b/swyft/store/simulator.py
@@ -307,10 +307,7 @@ class DaskSimulator:
 
 
 def _run_model_chunk(
-    z: np.ndarray,
-    model: Callable,
-    sim_shapes: SimShapeType,
-    fail_on_non_finite: bool,
+    z: np.ndarray, model: Callable, sim_shapes: SimShapeType, fail_on_non_finite: bool
 ):
     """Run the model over a set of input parameters.
 

--- a/swyft/utils/__init__.py
+++ b/swyft/utils/__init__.py
@@ -3,7 +3,7 @@ from swyft.utils.device import *
 from swyft.utils.mutils import *
 from swyft.utils.parameters import *
 from swyft.utils.plot import *
-from swyft.utils.plot import plot_corner, plot_1d, plot_empirical_mass
+from swyft.utils.plot import plot_1d, plot_corner, plot_empirical_mass
 from swyft.utils.utils import *
 from swyft.utils.wmutils import *
 

--- a/swyft/utils/__init__.py
+++ b/swyft/utils/__init__.py
@@ -3,8 +3,8 @@ from swyft.utils.device import *
 from swyft.utils.mutils import *
 from swyft.utils.parameters import *
 from swyft.utils.plot import *
-from swyft.utils.plot import corner, plot1d
+from swyft.utils.plot import plot_corner, plot_1d, plot_empirical_mass
 from swyft.utils.utils import *
 from swyft.utils.wmutils import *
 
-__all__ = ["plot1d", "corner"]
+__all__ = ["plot_1d", "plot_corner", "plot_empirical_mass"]

--- a/swyft/utils/plot.py
+++ b/swyft/utils/plot.py
@@ -3,6 +3,8 @@ import pandas as pd
 import pylab as plt
 import seaborn as sns
 from scipy.integrate import simps
+from typing import Dict
+from swyft.types import Array
 
 from swyft.utils.mutils import filter_marginals_by_dim
 from swyft.utils.utils import grid_interpolate_samples
@@ -156,7 +158,7 @@ def plot_posterior(
         return dict(mean=mean, mode=None, HDI1=None, HDI2=None, HDI3=None, entropy=None)
 
 
-def plot1d(
+def plot_1d(
     samples,
     pois,
     truth=None,
@@ -231,7 +233,7 @@ def plot1d(
     return fig, diags
 
 
-def corner(
+def plot_corner(
     samples,
     pois,
     bins=100,
@@ -339,6 +341,31 @@ def contour1d(z, v, levels, ax=plt, linestyles=None, color=None, **kwargs):
     #    zero_crossings = np.where(np.diff(np.sign(v-l*1.001)))[0]
     #    for c in z[zero_crossings]:
     #        ax.axvline(c, ls=linestyles[i], color = colors[i], **kwargs)
+
+
+def plot_empirical_mass(masses: Dict[str, Array]) -> None:
+    """Plot empirical vs nominal mass.
+
+    Args:
+        masses: Result from `swyft.Posteriors.empirical_mass()`
+
+    Example::
+
+        >>> masses = posteriors.empirical_mass()
+        >>> swyft.plot_empirical_mass(mass[(0,)])  # Plot empirical mass for 1-dim posterior for parameter 0
+    """
+    plt.plot(1-masses['nominal'], 1-masses['empirical'])
+    plt.xscale('log')
+    plt.yscale('log')
+    plt.gca().invert_xaxis()
+    plt.gca().invert_yaxis()
+    plt.plot([0, 1], [0, 1], 'k:')
+    plt.xlabel("1-Cn, Nominal HDI level")
+    plt.xlabel("Nominal HDI credible level")
+    plt.ylabel("Empirical HDI credible level")
+    cred = [0.683, 0.954, 0.997]
+    plt.xticks(1-np.array(cred), cred)
+    plt.yticks(1-np.array(cred), cred)
 
 
 if __name__ == "__main__":

--- a/swyft/utils/plot.py
+++ b/swyft/utils/plot.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pylab as plt
 import seaborn as sns
+from scipy.integrate import simps
 
 from swyft.utils.mutils import filter_marginals_by_dim
 from swyft.utils.utils import grid_interpolate_samples
@@ -14,7 +15,7 @@ def split_corner_axes(axes):
     return lower, diag, upper
 
 
-def get_contour_levels(x, cred_level=[0.68268, 0.95450, 0.99730]):
+def get_HDI_thresholds(x, cred_level=[0.68268, 0.95450, 0.99730]):
     x = x.flatten()
     x = np.sort(x)[::-1]  # Sort backwards
     total_mass = x.sum()
@@ -60,164 +61,6 @@ def violin_plot(
     return ax
 
 
-def plot1d(
-    samples,
-    pois,
-    truth=None,
-    bins=100,
-    figsize=(15, 10),
-    color="k",
-    labels=None,
-    label_args={},
-    ncol=None,
-    subplots_kwargs={},
-) -> None:
-    """Make beautiful 1-dim posteriors.
-
-    Args:
-        samples: Samples from `swyft.Posteriors.sample`
-        pois: List of parameters of interest
-        truth: Ground truth vector
-        bins: Number of bins used for histograms.
-        figsize: Size of figure
-        color: Color
-        labels: Custom labels (default is parameter names)
-        label_args: Custom label arguments
-        ncol: Number of panel columns
-        subplot_kwargs: Subplot kwargs
-    """
-
-    grid_interpolate = False
-
-    if ncol is None:
-        ncol = len(pois)
-    K = len(pois)
-    nrow = (K - 1) // ncol + 1
-
-    fig, axes = plt.subplots(nrow, ncol, figsize=figsize, **subplots_kwargs)
-    lb = 0.125
-    tr = 0.9
-    whspace = 0.15
-    fig.subplots_adjust(
-        left=lb, bottom=lb, right=tr, top=tr, wspace=whspace, hspace=whspace
-    )
-
-    if labels is None:
-        labels = [samples["pnames"][pois[i]] for i in range(K)]
-
-    for k in range(K):
-        if nrow == 1 and ncol > 1:
-            ax = axes[k]
-        elif nrow == 1 and ncol == 1:
-            ax = axes
-        else:
-            i, j = k % ncol, k // ncol
-            ax = axes[j, i]
-        plot_posterior(
-            samples,
-            pois[k],
-            ax=ax,
-            grid_interpolate=grid_interpolate,
-            color=color,
-            bins=bins,
-        )
-        ax.set_xlabel(labels[k], **label_args)
-        if truth is not None:
-            ax.axvline(truth[pois[k]], ls=":", color="r")
-    return fig, axes
-
-
-def corner(
-    samples,
-    pois,
-    bins=100,
-    truth=None,
-    figsize=(10, 10),
-    color="k",
-    labels=None,
-    label_args={},
-) -> None:
-    """Make a beautiful corner plot.
-
-    Args:
-        samples: Samples from `swyft.Posteriors.sample`
-        pois: List of parameters of interest
-        truth: Ground truth vector
-        bins: Number of bins used for histograms.
-        figsize: Size of figure
-        color: Color
-        labels: Custom labels (default is parameter names)
-        label_args: Custom label arguments
-    """
-    K = len(pois)
-    fig, axes = plt.subplots(K, K, figsize=figsize)
-    lb = 0.125
-    tr = 0.9
-    whspace = 0.1
-    fig.subplots_adjust(
-        left=lb, bottom=lb, right=tr, top=tr, wspace=whspace, hspace=whspace
-    )
-
-    if labels is None:
-        labels = [samples["pnames"][pois[i]] for i in range(K)]
-    for i in range(K):
-        for j in range(K):
-            ax = axes[i, j]
-            # Switch off upper left triangle
-            if i < j:
-                ax.set_yticklabels([])
-                ax.set_xticklabels([])
-                ax.set_xticks([])
-                ax.set_yticks([])
-                ax.set_frame_on(False)
-                continue
-
-            # Formatting labels
-            if j > 0 or i == 0:
-                ax.set_yticklabels([])
-                # ax.set_yticks([])
-            if i < K - 1:
-                ax.set_xticklabels([])
-                # ax.set_xticks([])
-            if i == K - 1:
-                ax.set_xlabel(labels[j], **label_args)
-            if j == 0 and i > 0:
-                ax.set_ylabel(labels[i], **label_args)
-
-            # Set limits
-            # ax.set_xlim(x_lims[j])
-            # if i != j:
-            #    ax.set_ylim(y_lims[i])
-
-            # 2-dim plots
-            if j < i:
-                plot_posterior(
-                    samples, [pois[j], pois[i]], ax=ax, color=color, bins=bins
-                )
-                if truth is not None:
-                    ax.axvline(truth[pois[j]], color="r")
-                    ax.axhline(truth[pois[i]], color="r")
-            if j == i:
-                plot_posterior(samples, pois[i], ax=ax, color=color, bins=bins)
-                if truth is not None:
-                    ax.axvline(truth[pois[i]], ls=":", color="r")
-    return fig, axes
-
-
-def contour1d(z, v, levels, ax=plt, linestyles=None, color=None, **kwargs):
-    y0 = -0.05 * v.max()
-    y1 = 1.1 * v.max()
-    ax.fill_between(z, y0, y1, where=v > levels[0], color=color, alpha=0.1)
-    ax.fill_between(z, y0, y1, where=v > levels[1], color=color, alpha=0.1)
-    ax.fill_between(z, y0, y1, where=v > levels[2], color=color, alpha=0.1)
-    # if not isinstance(colors, list):
-    #    colors = [colors]*len(levels)
-    # for i, l in enumerate(levels):
-    #    zero_crossings = np.where(np.diff(np.sign(v-l*1.001)))[0]
-    #    for c in z[zero_crossings]:
-    #        ax.axvline(c, ls=linestyles[i], color = colors[i], **kwargs)
-
-
 def plot_posterior(
     samples,
     pois,
@@ -226,6 +69,7 @@ def plot_posterior(
     grid_interpolate=False,
     bins=100,
     color="k",
+    contours=True,
     **kwargs
 ):
     if isinstance(pois, int):
@@ -265,17 +109,29 @@ def plot_posterior(
             v, e = np.histogram(x, weights=w, bins=bins, density=True)
             zm = (e[1:] + e[:-1]) / 2
 
-        levels = sorted(get_contour_levels(v))
-        contour1d(zm, v, levels, ax=ax, color=color)
+        levels = sorted(get_HDI_thresholds(v))
+        if contours:
+            contour1d(zm, v, levels, ax=ax, color=color)
         ax.plot(zm, v, color=color, **kwargs)
         ax.set_xlim([x.min(), x.max()])
         ax.set_ylim([-v.max() * 0.05, v.max() * 1.1])
+
+        # Diagnostics
+        mean = sum(w * x) / sum(w)
+        mode = zm[v == v.max()][0]
+        int2 = zm[v > levels[2]].min(), zm[v > levels[2]].max()
+        int1 = zm[v > levels[1]].min(), zm[v > levels[1]].max()
+        int0 = zm[v > levels[0]].min(), zm[v > levels[0]].max()
+        entropy = -simps(v * np.log(v), zm)
+        return dict(
+            mean=mean, mode=mode, HDI1=int2, HDI2=int1, HDI3=int0, entropy=entropy
+        )
     elif len(pois) == 2:
         # FIXME: use interpolation when grid_interpolate == True
         x = samples["v"][:, pois[0]]
         y = samples["v"][:, pois[1]]
         counts, xbins, ybins, _ = ax.hist2d(x, y, weights=w, bins=bins, cmap="gray_r")
-        levels = sorted(get_contour_levels(counts))
+        levels = sorted(get_HDI_thresholds(counts))
         try:
             ax.contour(
                 counts.T,
@@ -288,6 +144,201 @@ def plot_posterior(
             print("WARNING: 2-dim contours not well-defined.")
         ax.set_xlim([x.min(), x.max()])
         ax.set_ylim([y.min(), y.max()])
+
+        xm = (xbins[:-1] + xbins[1:]) / 2
+        ym = (ybins[:-1] + ybins[1:]) / 2
+
+        cx = counts.sum(axis=1)
+        cy = counts.sum(axis=0)
+
+        mean = (sum(xm * cx) / sum(cx), sum(ym * cy) / sum(cy))
+
+        return dict(mean=mean, mode=None, HDI1=None, HDI2=None, HDI3=None, entropy=None)
+
+
+def plot1d(
+    samples,
+    pois,
+    truth=None,
+    bins=100,
+    figsize=(15, 10),
+    color="k",
+    labels=None,
+    label_args={},
+    ncol=None,
+    subplots_kwargs={},
+    fig=None,
+    contours=True,
+) -> None:
+    """Make beautiful 1-dim posteriors.
+
+    Args:
+        samples: Samples from `swyft.Posteriors.sample`
+        pois: List of parameters of interest
+        truth: Ground truth vector
+        bins: Number of bins used for histograms.
+        figsize: Size of figure
+        color: Color
+        labels: Custom labels (default is parameter names)
+        label_args: Custom label arguments
+        ncol: Number of panel columns
+        subplot_kwargs: Subplot kwargs
+    """
+
+    grid_interpolate = False
+    diags = {}
+
+    if ncol is None:
+        ncol = len(pois)
+    K = len(pois)
+    nrow = (K - 1) // ncol + 1
+
+    if fig is None:
+        fig, axes = plt.subplots(nrow, ncol, figsize=figsize, **subplots_kwargs)
+    else:
+        axes = fig.get_axes()
+    lb = 0.125
+    tr = 0.9
+    whspace = 0.15
+    fig.subplots_adjust(
+        left=lb, bottom=lb, right=tr, top=tr, wspace=whspace, hspace=whspace
+    )
+
+    if labels is None:
+        labels = [samples["pnames"][pois[i]] for i in range(K)]
+
+    for k in range(K):
+        if nrow == 1 and ncol > 1:
+            ax = axes[k]
+        elif nrow == 1 and ncol == 1:
+            ax = axes
+        else:
+            i, j = k % ncol, k // ncol
+            ax = axes[j, i]
+        ret = plot_posterior(
+            samples,
+            pois[k],
+            ax=ax,
+            grid_interpolate=grid_interpolate,
+            color=color,
+            bins=bins,
+            contours=contours,
+        )
+        ax.set_xlabel(labels[k], **label_args)
+        if truth is not None:
+            ax.axvline(truth[pois[k]], ls=":", color="r")
+        diags[(pois[k],)] = ret
+    return fig, diags
+
+
+def corner(
+    samples,
+    pois,
+    bins=100,
+    truth=None,
+    figsize=(10, 10),
+    color="k",
+    labels=None,
+    label_args={},
+    contours_1d: bool = True,
+    fig=None,
+) -> None:
+    """Make a beautiful corner plot.
+
+    Args:
+        samples: Samples from `swyft.Posteriors.sample`
+        pois: List of parameters of interest
+        truth: Ground truth vector
+        bins: Number of bins used for histograms.
+        figsize: Size of figure
+        color: Color
+        labels: Custom labels (default is parameter names)
+        label_args: Custom label arguments
+        contours_1d: Plot 1-dim contours
+        fig: Figure instance
+    """
+    K = len(pois)
+    if fig is None:
+        fig, axes = plt.subplots(K, K, figsize=figsize)
+        print(axes)
+    else:
+        axes = np.array(fig.get_axes()).reshape((K, K))
+    lb = 0.125
+    tr = 0.9
+    whspace = 0.1
+    fig.subplots_adjust(
+        left=lb, bottom=lb, right=tr, top=tr, wspace=whspace, hspace=whspace
+    )
+
+    diagnostics = {}
+
+    if labels is None:
+        labels = [samples["pnames"][pois[i]] for i in range(K)]
+    for i in range(K):
+        for j in range(K):
+            ax = axes[i, j]
+            # Switch off upper left triangle
+            if i < j:
+                ax.set_yticklabels([])
+                ax.set_xticklabels([])
+                ax.set_xticks([])
+                ax.set_yticks([])
+                ax.set_frame_on(False)
+                continue
+
+            # Formatting labels
+            if j > 0 or i == 0:
+                ax.set_yticklabels([])
+                # ax.set_yticks([])
+            if i < K - 1:
+                ax.set_xticklabels([])
+                # ax.set_xticks([])
+            if i == K - 1:
+                ax.set_xlabel(labels[j], **label_args)
+            if j == 0 and i > 0:
+                ax.set_ylabel(labels[i], **label_args)
+
+            # Set limits
+            # ax.set_xlim(x_lims[j])
+            # if i != j:
+            #    ax.set_ylim(y_lims[i])
+
+            # 2-dim plots
+            if j < i:
+                ret = plot_posterior(
+                    samples, [pois[j], pois[i]], ax=ax, color=color, bins=bins
+                )
+                if truth is not None:
+                    ax.axvline(truth[pois[j]], color="r")
+                    ax.axhline(truth[pois[i]], color="r")
+                diagnostics[(pois[j], pois[i])] = ret
+            if j == i:
+                ret = plot_posterior(
+                    samples,
+                    pois[i],
+                    ax=ax,
+                    color=color,
+                    bins=bins,
+                    contours=contours_1d,
+                )
+                if truth is not None:
+                    ax.axvline(truth[pois[i]], ls=":", color="r")
+                diagnostics[(pois[i],)] = ret
+    return fig, diagnostics
+
+
+def contour1d(z, v, levels, ax=plt, linestyles=None, color=None, **kwargs):
+    y0 = -1.0 * v.max()
+    y1 = 5.0 * v.max()
+    ax.fill_between(z, y0, y1, where=v > levels[0], color=color, alpha=0.1)
+    ax.fill_between(z, y0, y1, where=v > levels[1], color=color, alpha=0.1)
+    ax.fill_between(z, y0, y1, where=v > levels[2], color=color, alpha=0.1)
+    # if not isinstance(colors, list):
+    #    colors = [colors]*len(levels)
+    # for i, l in enumerate(levels):
+    #    zero_crossings = np.where(np.diff(np.sign(v-l*1.001)))[0]
+    #    for c in z[zero_crossings]:
+    #        ax.axvline(c, ls=linestyles[i], color = colors[i], **kwargs)
 
 
 if __name__ == "__main__":

--- a/swyft/utils/plot.py
+++ b/swyft/utils/plot.py
@@ -1,11 +1,12 @@
+from typing import Dict
+
 import numpy as np
 import pandas as pd
 import pylab as plt
 import seaborn as sns
 from scipy.integrate import simps
-from typing import Dict
-from swyft.types import Array
 
+from swyft.types import Array
 from swyft.utils.mutils import filter_marginals_by_dim
 from swyft.utils.utils import grid_interpolate_samples
 
@@ -354,18 +355,18 @@ def plot_empirical_mass(masses: Dict[str, Array]) -> None:
         >>> masses = posteriors.empirical_mass()
         >>> swyft.plot_empirical_mass(mass[(0,)])  # Plot empirical mass for 1-dim posterior for parameter 0
     """
-    plt.plot(1-masses['nominal'], 1-masses['empirical'])
-    plt.xscale('log')
-    plt.yscale('log')
+    plt.plot(1 - masses["nominal"], 1 - masses["empirical"])
+    plt.xscale("log")
+    plt.yscale("log")
     plt.gca().invert_xaxis()
     plt.gca().invert_yaxis()
-    plt.plot([0, 1], [0, 1], 'k:')
+    plt.plot([0, 1], [0, 1], "k:")
     plt.xlabel("1-Cn, Nominal HDI level")
     plt.xlabel("Nominal HDI credible level")
     plt.ylabel("Empirical HDI credible level")
     cred = [0.683, 0.954, 0.997]
-    plt.xticks(1-np.array(cred), cred)
-    plt.yticks(1-np.array(cred), cred)
+    plt.xticks(1 - np.array(cred), cred)
+    plt.yticks(1 - np.array(cred), cred)
 
 
 if __name__ == "__main__":

--- a/swyft/utils/utils.py
+++ b/swyft/utils/utils.py
@@ -103,26 +103,28 @@ def get_entropy_1d(x, y, y_true=None, x_true=None, bins=1000):
     return result
 
 
+# TODO: Deprecated - remove?
 def sample_diagnostics(samples, true_posteriors={}, true_params={}):
-   result = {}
-   for params in samples["weights"].keys():
-       if len(params) > 1:
-           continue
-       else:  # 1-dim case
-           x = samples["v"][params[0]]
-           y = samples["weights"][params]
-           if params in true_posteriors.keys():
-               y_true = true_posteriors[params]
-           else:
-               y_true = None
-           if params[0] in true_params.keys():
-               x_true = true_params[params[0]]
-           else:
-               x_true = None
-           result[params] = get_entropy_1d(x, y, y_true=y_true, x_true=x_true)
-   return result
+    result = {}
+    for params in samples["weights"].keys():
+        if len(params) > 1:
+            continue
+        else:  # 1-dim case
+            x = samples["v"][params[0]]
+            y = samples["weights"][params]
+            if params in true_posteriors.keys():
+                y_true = true_posteriors[params]
+            else:
+                y_true = None
+            if params[0] in true_params.keys():
+                x_true = true_params[params[0]]
+            else:
+                x_true = None
+            result[params] = get_entropy_1d(x, y, y_true=y_true, x_true=x_true)
+    return result
 
 
+# TODO: Remove?  Deprecated
 def estimate_coverage(
     post,
     dataset,

--- a/swyft/utils/utils.py
+++ b/swyft/utils/utils.py
@@ -103,24 +103,24 @@ def get_entropy_1d(x, y, y_true=None, x_true=None, bins=1000):
     return result
 
 
-# def sample_diagnostics(samples, true_posteriors={}, true_params={}):
-#    result = {}
-#    for params in samples["weights"].keys():
-#        if len(params) > 1:
-#            continue
-#        else:  # 1-dim case
-#            x = samples["v"][params[0]]
-#            y = samples["weights"][params]
-#            if params in true_posteriors.keys():
-#                y_true = true_posteriors[params]
-#            else:
-#                y_true = None
-#            if params[0] in true_params.keys():
-#                x_true = true_params[params[0]]
-#            else:
-#                x_true = None
-#            result[params] = get_entropy_1d(x, y, y_true=y_true, x_true=x_true)
-#    return result
+def sample_diagnostics(samples, true_posteriors={}, true_params={}):
+   result = {}
+   for params in samples["weights"].keys():
+       if len(params) > 1:
+           continue
+       else:  # 1-dim case
+           x = samples["v"][params[0]]
+           y = samples["weights"][params]
+           if params in true_posteriors.keys():
+               y_true = true_posteriors[params]
+           else:
+               y_true = None
+           if params[0] in true_params.keys():
+               x_true = true_params[params[0]]
+           else:
+               x_true = None
+           result[params] = get_entropy_1d(x, y, y_true=y_true, x_true=x_true)
+   return result
 
 
 def estimate_coverage(


### PR DESCRIPTION
A few improvements relevant for the upcoming release:
- Added `empirical_mass` method to `Posteriors` class, which allows to easily estimate the empirical mass vs nominal mass for trained posterior networks. This works for all posteriors simultaneously and in all dimensions.
- Some improvements to plotting routines, in order to make them composable.

Closes #39 