### PR TITLE
remove unstable simulator tests

### DIFF
--- a/tests/simulator_test.py
+++ b/tests/simulator_test.py
@@ -281,44 +281,6 @@ class TestDaskSimulator(unittest.TestCase):
                 assert np.all(sim_status == SimulationStatus.FINISHED)
                 assert not np.all(np.isclose(sims["x"].sum(axis=1), 0.0))
 
-    def test_run_simulator_with_threads_and_numpy_array(self):
-        """
-        If the store is in memory (here a Numpy array) and the Dask workers share
-        memory with the client (i.e. we have a threads-based cluster),
-        collect_in_memory can be set to False.
-        """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with LocalCluster(
-                n_workers=2,
-                processes=False,
-                threads_per_worker=1,
-                local_directory=tmpdir,
-            ) as cluster:
-                simulator = DaskSimulator(
-                    model, sim_shapes=dict(x=(10,)), parameter_names=2
-                )
-                simulator.set_dask_cluster(cluster)
-
-                pars = np.random.random((100, 2))
-                sims = dict(x=np.zeros((100, 10)))
-                sim_status = np.full(100, SimulationStatus.RUNNING, dtype=int)
-
-                # the following is non-blocking (it immediately returns)
-                simulator._run(
-                    v=pars,
-                    sims=sims,
-                    sim_status=sim_status,
-                    indices=np.arange(100, dtype=int),
-                    collect_in_memory=False,
-                    batch_size=20,
-                )
-
-                # need to wait for tasks to be completed
-                _wait_for_all_tasks()
-
-                assert np.all(sim_status == SimulationStatus.FINISHED)
-                assert not np.all(np.isclose(sims["x"].sum(axis=1), 0.0))
-
     def test_run_simulator_with_processes_and_zarr_memory_store(self):
         """
         If the store is in memory (here a Zarr MemoryStore) and the Dask workers do
@@ -351,46 +313,6 @@ class TestDaskSimulator(unittest.TestCase):
                     collect_in_memory=True,
                     batch_size=20,
                 )
-
-                assert np.all(sim_status[:] == SimulationStatus.FINISHED)
-                assert not np.all(np.isclose(sims["x"][:, :].sum(axis=1), 0.0))
-
-    def test_run_simulator_with_threads_and_zarr_memory_store(self):
-        """
-        If the store is in memory (here a Zarr MemoryStore) and the Dask workers
-        share memory with the client (i.e. we have a threads-based cluster),
-        collect_in_memory can be set to False.
-        """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with LocalCluster(
-                n_workers=2,
-                processes=False,
-                threads_per_worker=1,
-                local_directory=tmpdir,
-            ) as cluster:
-                simulator = DaskSimulator(
-                    model, sim_shapes=dict(x=(10,)), parameter_names=2
-                )
-                simulator.set_dask_cluster(cluster)
-
-                pars = zarr.zeros((100, 2))
-                pars[:, :] = np.random.random(pars.shape)
-                x = zarr.zeros((100, 10))
-                sims = dict(x=x.oindex)
-                sim_status = zarr.full(100, SimulationStatus.RUNNING, dtype="int")
-
-                # the following is non-blocking (it immediately returns)
-                simulator._run(
-                    v=pars,
-                    sims=sims,
-                    sim_status=sim_status.oindex,
-                    indices=np.arange(100, dtype=int),
-                    collect_in_memory=False,
-                    batch_size=20,
-                )
-
-                # need to wait for tasks to be completed
-                _wait_for_all_tasks()
 
                 assert np.all(sim_status[:] == SimulationStatus.FINISHED)
                 assert not np.all(np.isclose(sims["x"][:, :].sum(axis=1), 0.0))


### PR DESCRIPTION
Removing some unstable tests that are actually not relevant since a `Store` based on Zarr MemoryStore will call the simulator with `collect_in_memory=True`. 