### PR TITLE
Enable online data generation and some simulation reuse

### DIFF
--- a/swyft/lightning/components.py
+++ b/swyft/lightning/components.py
@@ -127,7 +127,14 @@ class SwyftModelForward:
             result = {k: self._to_tensor(v) for k, v in result.items()}
             out.append(result)
         return self._collate_output(out, dtype)
-    
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        result = self._run()
+        return {k: self._to_tensor(v, self.dtype) for k, v in result.items()}
+
 
 class SwyftModel:
     def _simulate(self, N, bounds = None, effective_prior = None):

--- a/swyft/lightning/online.py
+++ b/swyft/lightning/online.py
@@ -1,0 +1,93 @@
+from typing import Iterator, Optional
+
+import pytorch_lightning as pl
+from torchdata.datapipes.iter import IterableWrapper
+from torch.utils.data import DataLoader
+
+from . import SwyftModelForward
+
+
+def truncate_iterator(it: Iterator, n) -> Iterator:
+    """
+    Truncates an iterator.
+
+    Args:
+        n: maximum length of truncated Iterator
+
+    Return:
+        ``it``, truncated to return at most ``n`` values.
+    """
+    for _ in range(n):
+        try:
+            yield next(it)
+        except StopIteration:
+            break
+
+
+class SwyftOnlineDataModule(pl.LightningDataModule):
+    """
+    A data module that directly wraps the simulator to generate data online. Works
+    with batched simulators.
+
+    Notes:
+        This has many subtleties when the simulator uses CUDA and ``num_workers``
+        is greater than 0.
+    """
+
+    def __init__(
+        self,
+        simulator: SwyftModelForward,
+        n_train: int,
+        n_val: int,
+        n_test: int,
+        batch_size: int,
+        num_workers: int = 0,
+    ):
+        super().__init__()
+
+        # Tell the dataloaders whether the simulator is batched. After this block,
+        # self.batch_size contains the batch size used by the dataloaders and
+        # self._dl_batch_size contains the argument passed to the dataloaders.
+        if simulator.batch_size is not None:
+            if batch_size is not None and batch_size != simulator.batch_size:
+                raise ValueError(
+                    "conflicting values for simulator and explicit batch_size"
+                )
+            self.batch_size = simulator.batch_size
+            self._dl_batch_size = None
+        elif batch_size is not None and batch_size >= 2:
+            self.batch_size = self._dl_batch_size = batch_size
+        else:
+            raise ValueError("batch_size must be >= 2")
+
+        if n_train % self.batch_size != 0:
+            raise ValueError("n_train must be a multiple of batch_size")
+        if n_val % self.batch_size != 0:
+            raise ValueError("n_val must be a multiple of batch_size")
+        if n_test % self.batch_size != 0:
+            raise ValueError("n_test must be a multiple of batch_size")
+
+        self.save_hyperparameters(ignore=("simulator", "batch_size"))
+        self.simulator = simulator
+
+    def setup(self, _: Optional[str] = None):
+        it_train = truncate_iterator(self.simulator, self.hparams.n_train)  # type: ignore
+        self.dp_train = IterableWrapper(it_train)
+
+        it_val = truncate_iterator(self.simulator, self.hparams.n_val)  # type: ignore
+        self.dp_val = IterableWrapper(it_val)
+
+        it_test = truncate_iterator(self.simulator, self.hparams.n_test)  # type: ignore
+        self.dp_test = IterableWrapper(it_test)
+
+    def train_dataloader(self):
+        return DataLoader(self.dp_train, self._dl_batch_size, num_workers=self.hparams.num_workers)  # type: ignore
+
+    def val_dataloader(self):
+        return DataLoader(self.dp_val, self._dl_batch_size, num_workers=self.hparams.num_workers)  # type: ignore
+
+    def test_dataloader(self):
+        return DataLoader(self.dp_test, self._dl_batch_size, num_workers=self.hparams.num_workers)  # type: ignore
+
+    def samples(self, n):  # TODO: deprecate
+        return self.simulator.sample(n)

--- a/swyft/lightning/torchstore.py
+++ b/swyft/lightning/torchstore.py
@@ -1,0 +1,83 @@
+import os
+
+import torch
+from . import SwyftModelForward, SampleStore
+
+class TorchStore:
+    """
+    A very simple store using torch tensors.
+    """
+    def __init__(self, store_path: str, simulator: SwyftModelForward):
+        self.store_path = store_path
+        self.simulator = simulator
+        self.samples = None
+        if os.path.exists(self.store_path):
+            raise RuntimeError(
+                "A store already exists at this path. TorchStores should not "
+                "be reused as bounds will differ for different training runs."
+            )
+
+    def simulate(self, n: int, force_add: bool = False, verbose: bool = True):
+        """
+        Loads and potentially adds simulations to the store using the
+        simulator's prior bounds.
+
+        Args:
+            n: number of simulations to return
+            force_add: if ``True``, ``n`` new simulations will be added to the
+                store, regardless of how many currently lie within bounds
+            verbose: if ``True``, prints useful messages
+
+        Returns:
+            ``n`` samples from the simulator using its current prior bounds. If
+            ``force_add` is false, this will contain simulations in the store
+            lying in bounds. If the store does not contain ``n`` simulations in
+            bounds, more will be added and saved. If ``force_add`` is false,
+            ``n`` new simulations will be added to the store.
+        """
+        if not os.path.exists(self.store_path):
+            if verbose:
+                print(f"creating new store with {n} samples")
+            self.samples = self.simulator.sample(n)
+            torch.save(self.samples, self.store_path)
+        else:
+            all_samples = torch.load(self.store_path)
+            if verbose:
+                print(f"loaded store with {len(all_samples)} samples")
+
+            idx = 0  # will be equal to number of samples in bounds after loop
+            # Allocate tensor for samples
+            self.samples = SampleStore(
+                {k: torch.zeros(n, *v.shape[1:]) for k, v in all_samples.items()}
+            )
+            if not force_add:
+                for i in range(len(all_samples)):
+                    # If in bounds, copy into samples
+                    sample = all_samples[i]
+                    if self.simulator.in_bounds(sample):
+                        for k in self.samples:
+                            self.samples[k][idx] = sample[k]
+                        idx += 1
+                    if idx == n:
+                        break
+
+            if idx < n:
+                if verbose:
+                    print(f"running {n - idx} new sims")
+
+                # Run new simulations and save
+                new_samples = self.simulator.sample(n - idx)
+
+                for k in self.samples:
+                    self.samples[k][idx:] = new_samples[k]
+
+                torch.save(
+                    SampleStore(
+                        {k: torch.cat((v, new_samples[k])) for k, v in all_samples.items()}
+                    ),
+                    self.store_path,
+                )
+            elif verbose:
+                print("no simulations required")
+
+        return self.samples

--- a/swyft/lightning/torchstore.py
+++ b/swyft/lightning/torchstore.py
@@ -11,11 +11,6 @@ class TorchStore:
         self.store_path = store_path
         self.simulator = simulator
         self.samples = None
-        if os.path.exists(self.store_path):
-            raise RuntimeError(
-                "A store already exists at this path. TorchStores should not "
-                "be reused as bounds will differ for different training runs."
-            )
 
     def simulate(self, n: int, force_add: bool = False, verbose: bool = True):
         """


### PR DESCRIPTION
Makes the following changes:

- Adds `TorchStore`, which allows simulation reuse between rounds, but _only for a single training run_.
- Make `SwyftModel` into an `Iterator` and add `SwyftOnlineDatastore` to make it simple to generate training data online (at least, for CPU-based models).
- Bugfix in `SwyftTrainer`.