### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     toolz>=0.10.0
     numpy>=1.18.1
     torch>=1.10.2
-    pytorch_lightning>=1.5.10
+    pytorch_lightning>=1.5.10, <=1.9.0
     zarr>=2.5.0
     matplotlib>=3.1.3
     scipy>=1.4.1


### PR DESCRIPTION
We cannot handle pytorch_lightning 2.0.0 right now. Updated setup.cfg accordingly.